### PR TITLE
docs(readme): fix mislabel and broken Pydantic links

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ Python and Rust developer. I work on infrastructure, backend and databases.
   </thead>
   <tbody>
    <tr>
-      <td><a href="https://github.com/apache/datafusion/issues?q=author%3Aadriangb"><b>Pydantic</b></a></td>
+      <td><a href="https://github.com/apache/datafusion/issues?q=author%3Aadriangb"><b>Datafusion</b></a></td>
       <td>Predicate pruning for LIKE expressions making some queries order of magnitude faster. Several bug fixes and improvements.</td>
     </tr>
    <tr>
-      <td><a href="https://github.com/pydantic/issues?q=author%3Aadriangb"><b>Pydantic</b></a></td>
+      <td><a href="https://github.com/pydantic/pydantic/issues?q=author%3Aadriangb"><b>Pydantic</b></a></td>
       <td>Maintainer.</td>
     </tr>
     <tr>


### PR DESCRIPTION
Fix two links in the README “Contributions” table.

- The first entry labeled “Pydantic” actually refers to Apache DataFusion (LIKE/predicate work). Relabel to “DataFusion” and keep the DataFusion issues URL.
- The second “Pydantic” link is dead. Update it to the canonical repo URL.

Updated targets:
- DataFusion: https://github.com/apache/datafusion/issues?q=author%3Aadriangb
- Pydantic: https://github.com/pydantic/pydantic/issues?q=author%3Aadriangb

No content changes beyond labels/URLs. 

Will delete my fork after this is merged to reduce clutter.